### PR TITLE
Prevent timing attacks by using a fake hash when user does not exist

### DIFF
--- a/jwt_issuer.go
+++ b/jwt_issuer.go
@@ -181,6 +181,11 @@ func (m *JWTIssuer) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 	userEntry, exists := m.users[providedCredentials.Username]
 	m.usersMutex.RUnlock()
 	if !exists {
+		// Use a fake hash to prevent timing attacks
+		// The cost of 14 is chosen to match the bcrypt cost used for real passwords
+		// This prevents attackers from knowing if a user does not exist based on the time taken
+		fakeHash := "$2a$14$BS8pSBcO76nFFFvzQuZuPe5nahDaA2QkXaUnUp4ND6k1ax4Ohi39m"
+		bcrypt.CompareHashAndPassword([]byte(fakeHash), []byte(providedCredentials.Password))
 		logger.Warn("Authentication failed due to incorrect username",
 			zap.String("username", providedCredentials.Username),
 		)


### PR DESCRIPTION
This pull request addresses a security vulnerability in the user authentication process where timing discrepancies can reveal whether a user exists in the user database. Currently, if a user does not exist, the authentication process is significantly quicker, allowing potential timing attacks that can enumerate valid usernames. This change introduces a consistent time delay by using a fake hash comparison when the user record is not found, thus masking the presence or absence of user data.