### PR TITLE
Security Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To use the caddy-jwt-issuer plugin, add the following directive to your Caddyfil
   - `cookie_domain`: The domain for which the cookie is valid. For example, `.example.com` makes the cookie valid for all subdomains of `example.com`.
   - `omit_token_in_response`: If this option is present, the JWT will not be included in the JSON response body. This is useful when the token is only delivered via cookie.
 - **`token_is_blocked`**:
-  - `blocklist_file`: Path to the blocklist file containing revoked tokens. Each line may contain just the token/JTI for backward compatibility, or the token/JTI followed by a Unix expiration timestamp, e.g. `<jti> <exp>`. The file is automatically reloaded when modified. Entries with an expiration timestamp in the past are skipped when loaded into memory.
+  - `blocklist_file`: Path to the blocklist file containing revoked tokens. Each line may contain just the token/JTI for backward compatibility, or the token/JTI followed by an expiration timestamp, e.g. `<jti> <exp>`. The expiration may be Unix seconds or RFC3339/RFC3339Nano. The file is automatically reloaded when modified. Entries with an expiration timestamp in the past are skipped when loaded into memory.
   - `placeholder`: Placeholder containing the token to check (e.g., `{http.auth.user.jti}`). Defaults to `{http.auth.user.jti}`. The matcher is read-only: it filters expired entries while loading but does not rewrite or compact the blocklist file.
 
 ### Example: Protecting an API Endpoint

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ To use the caddy-jwt-issuer plugin, add the following directive to your Caddyfil
   - `cookie_domain`: The domain for which the cookie is valid. For example, `.example.com` makes the cookie valid for all subdomains of `example.com`.
   - `omit_token_in_response`: If this option is present, the JWT will not be included in the JSON response body. This is useful when the token is only delivered via cookie.
 - **`token_is_blocked`**:
-  - `blocklist_file`: Path to the blocklist file containing revoked tokens (one token per line). The file is automatically reloaded when modified.
-  - `placeholder`: Placeholder containing the token to check (e.g., `{http.auth.user.jti}`). Defaults to `{http.auth.user.jti}`.
+  - `blocklist_file`: Path to the blocklist file containing revoked tokens. Each line may contain just the token/JTI for backward compatibility, or the token/JTI followed by a Unix expiration timestamp, e.g. `<jti> <exp>`. The file is automatically reloaded when modified. Entries with an expiration timestamp in the past are skipped when loaded into memory.
+  - `placeholder`: Placeholder containing the token to check (e.g., `{http.auth.user.jti}`). Defaults to `{http.auth.user.jti}`. The matcher is read-only: it filters expired entries while loading but does not rewrite or compact the blocklist file.
 
 ### Example: Protecting an API Endpoint
 

--- a/api.go
+++ b/api.go
@@ -27,9 +27,9 @@ type apiResponse struct {
 // jsonResponse sends a generic JSON response with a message and optional token
 func jsonResponse(w http.ResponseWriter, statusCode int, response apiResponse) {
 	w.Header().Set("Content-Type", "application/json")
-	// Prevent storage in intermediaries
-	w.Header().Set("Cache-Control", "private")
-	w.Header().Set("Pragma", "private")
+	// Token-bearing responses must not be stored by browsers or intermediaries.
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(statusCode)
 	json.NewEncoder(w).Encode(response)
 }

--- a/example/Caddyfile
+++ b/example/Caddyfile
@@ -130,12 +130,14 @@ auth.example.com {
 			import snippet_check_token_blocklist
 
 			# Note:
-			# On Logout, the JTI is added to the file jti_blocklist.txt
+			# On logout, the JTI and JWT expiration timestamp are added to jti_blocklist.txt.
+			# token_is_blocked also accepts older files with only one JTI per line.
+			# Expired entries are skipped in memory, but the matcher does not rewrite this file.
 			# The directive placeholder_dump requires the caddy-placeholder-dump plugin (https://github.com/steffenbusch/caddy-placeholder-dump)
 			# Attention: You should not let this file grow indefinitely. If you change the jwtauth sign_key, clear the content of this file.
 			placeholder_dump /logout.html {
 				file jti_blocklist.txt
-				content "{http.auth.user.jti}"
+				content "{http.auth.user.jti} {http.auth.user.exp}"
 			}
 
 			# Additonally, delete the cookie

--- a/example/Caddyfile
+++ b/example/Caddyfile
@@ -130,7 +130,7 @@ auth.example.com {
 			import snippet_check_token_blocklist
 
 			# Note:
-			# On logout, the JTI and JWT expiration timestamp are added to jti_blocklist.txt.
+			# On logout, the JTI and RFC3339 JWT expiration timestamp are added to jti_blocklist.txt.
 			# token_is_blocked also accepts older files with only one JTI per line.
 			# Expired entries are skipped in memory, but the matcher does not rewrite this file.
 			# The directive placeholder_dump requires the caddy-placeholder-dump plugin (https://github.com/steffenbusch/caddy-placeholder-dump)

--- a/example/README.md
+++ b/example/README.md
@@ -46,7 +46,7 @@ A folder containing static HTML files for the login, logout, and portal pages:
 
 2. **Update Configuration**:
    - Adjust placeholders in the `Caddyfile` (e.g., `{file./path/to/jwt-secret.txt}`) with actual values.
-   - Configure the `blocklist_file` option in the `token_is_blocked` matcher to specify the path to the blocklist file. The example writes lines as `<jti> <exp>` so the matcher can skip already expired revocations in memory while remaining compatible with older one-JTI-per-line files.
+   - Configure the `blocklist_file` option in the `token_is_blocked` matcher to specify the path to the blocklist file. The example writes lines as `<jti> <exp>` using the RFC3339 value exposed by `{http.auth.user.exp}`, so the matcher can skip already expired revocations in memory while remaining compatible with older one-JTI-per-line files.
 
 3. **Start Caddy**:
    - Run the Caddy server using the provided `Caddyfile`.
@@ -58,7 +58,7 @@ A folder containing static HTML files for the login, logout, and portal pages:
 ## Notes
 
 - The `jwt_issuer` directive is responsible for issuing tokens, while the `jwtauth` directive validates them.
-- The `token_is_blocked` matcher ensures that revoked tokens are blocked by referencing a blocklist file. It reads the first whitespace-separated field as the token/JTI and optionally uses the second field as the JWT expiration timestamp.
+- The `token_is_blocked` matcher ensures that revoked tokens are blocked by referencing a blocklist file. It reads the first whitespace-separated field as the token/JTI and optionally uses the second field as the JWT expiration timestamp. Expiration values may be Unix seconds or RFC3339/RFC3339Nano timestamps.
 - The `extra-placeholders` module is used to handle redirection with query parameters.
 - Ensure the `example-users.json` file and the blocklist file are properly secured and not exposed publicly.
 

--- a/example/README.md
+++ b/example/README.md
@@ -19,7 +19,7 @@ The main configuration file for the Caddy server. It includes:
 - **`auth.example.com`**:
   - Handles login and token issuance using the `jwt_issuer` directive.
   - Protects the `/portal.html` and `/logout.html` endpoint with JWT authentication.
-  - Upon logout, the HTTP cookie is cleared, and the JWT's JTI is added to a blocklist file as specified by the `placeholder_dump` configuration.
+  - Upon logout, the HTTP cookie is cleared, and the JWT's JTI plus expiration timestamp are added to a blocklist file as specified by the `placeholder_dump` configuration.
     For more information about the `placeholder_dump` directive, visit its [GitHub repository](https://github.com/steffenbusch/caddy-placeholder-dump).
   - Redirects unauthenticated users to the login page.
 - **`app1.example.com`** and **`app2.example.com`**:
@@ -46,7 +46,7 @@ A folder containing static HTML files for the login, logout, and portal pages:
 
 2. **Update Configuration**:
    - Adjust placeholders in the `Caddyfile` (e.g., `{file./path/to/jwt-secret.txt}`) with actual values.
-   - Configure the `blocklist_file` option in the `token_is_blocked` matcher to specify the path to the blocklist file.
+   - Configure the `blocklist_file` option in the `token_is_blocked` matcher to specify the path to the blocklist file. The example writes lines as `<jti> <exp>` so the matcher can skip already expired revocations in memory while remaining compatible with older one-JTI-per-line files.
 
 3. **Start Caddy**:
    - Run the Caddy server using the provided `Caddyfile`.
@@ -58,7 +58,7 @@ A folder containing static HTML files for the login, logout, and portal pages:
 ## Notes
 
 - The `jwt_issuer` directive is responsible for issuing tokens, while the `jwtauth` directive validates them.
-- The `token_is_blocked` matcher ensures that revoked tokens are blocked by referencing a blocklist file.
+- The `token_is_blocked` matcher ensures that revoked tokens are blocked by referencing a blocklist file. It reads the first whitespace-separated field as the token/JTI and optionally uses the second field as the JWT expiration timestamp.
 - The `extra-placeholders` module is used to handle redirection with query parameters.
 - Ensure the `example-users.json` file and the blocklist file are properly secured and not exposed publicly.
 

--- a/jwt.go
+++ b/jwt.go
@@ -16,6 +16,7 @@ package jwtissuer
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
@@ -138,8 +139,11 @@ func (m *JWTIssuer) createJWT(user user, clientIP string, ctx context.Context) (
 		"ip":  clientIP, // Include client IP as a claim
 	}
 
-	// Fetch replacer from the request context
-	repl := ctx.Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	// Fetch replacer from the request context. Caddy normally provides this; fail closed if it is missing.
+	repl, ok := ctx.Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	if !ok || repl == nil {
+		return "", nil, fmt.Errorf("caddy replacer missing from request context")
+	}
 
 	// Add meta_claims to the JWT claims, excluding predefined claims
 	for key, value := range user.MetaClaims {

--- a/jwt.go
+++ b/jwt.go
@@ -41,8 +41,16 @@ func predefinedClaims() map[string]bool {
 	}
 }
 
+func maskTokenForLog(token string) string {
+	const visibleTailChars = 24
+	if len(token) <= visibleTailChars {
+		return "[redacted]"
+	}
+	return "[redacted]…" + token[len(token)-visibleTailChars:]
+}
+
 func logJWTDetails(logger *zap.Logger, tokenString string, token *jwt.Token) {
-	logger.Debug("Encoded JWT", zap.String("jwt", tokenString))
+	logger.Debug("Encoded JWT", zap.String("jwt", maskTokenForLog(tokenString)))
 
 	// Log the JWT claims
 	claims := token.Claims.(jwt.MapClaims)

--- a/jwt_issuer.go
+++ b/jwt_issuer.go
@@ -291,20 +291,20 @@ func (m *JWTIssuer) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 
 // getClientIP retrieves the client IP address directly from the Caddy context.
 func getClientIP(ctx context.Context, remoteAddr string) string {
-	clientIP, ok := ctx.Value(caddyhttp.VarsCtxKey).(map[string]any)["client_ip"]
-	if ok {
-		if ip, valid := clientIP.(string); valid {
-			return ip
+	// Prefer the client IP that Caddy resolved into the request context.
+	if vars, ok := ctx.Value(caddyhttp.VarsCtxKey).(map[string]any); ok {
+		if clientIP, ok := vars["client_ip"].(string); ok && clientIP != "" {
+			return clientIP
 		}
 	}
-	// If the client IP is empty, extract it from the request's RemoteAddr.
-	var err error
-	clientIP, _, err = net.SplitHostPort(remoteAddr)
+
+	// If the Caddy context value is missing, extract the host from RemoteAddr.
+	clientIP, _, err := net.SplitHostPort(remoteAddr)
 	if err != nil {
 		// Use the complete RemoteAddr string as a last resort.
-		clientIP = remoteAddr
+		return remoteAddr
 	}
-	return clientIP.(string)
+	return clientIP
 }
 
 // Interface guards to ensure JWTIssuer implements the necessary interfaces.

--- a/jwt_issuer_test.go
+++ b/jwt_issuer_test.go
@@ -228,6 +228,59 @@ func TestJWTIssuer_ServeHTTP_OmitToken(t *testing.T) {
 	}
 }
 
+func TestJWTIssuer_ServeHTTP_MissingReplacerContext(t *testing.T) {
+	signKey := base64.StdEncoding.EncodeToString([]byte("12345678901234567890123456789012"))
+	pw, _ := bcrypt.GenerateFromPassword([]byte("testpass"), 14)
+	users := map[string]any{
+		"bob": map[string]any{
+			"password": string(pw),
+			"audience": []string{"testaud"},
+		},
+	}
+	userDB := createTestUserDBFile(t, users)
+	defer os.Remove(userDB)
+
+	issuer := &JWTIssuer{
+		SignKey:              signKey,
+		UserDBPath:           userDB,
+		TokenIssuer:          "test-issuer",
+		DefaultTokenLifetime: 10 * time.Minute,
+	}
+	issuer.logger = zaptest.NewLogger(t)
+	var stubCaddyCtx caddy.Context
+	if err := issuer.Provision(stubCaddyCtx); err != nil {
+		t.Fatalf("Provision failed: %v", err)
+	}
+
+	body, _ := json.Marshal(credentials{
+		Username: "bob",
+		Password: "testpass",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/jwt", bytes.NewReader(body))
+	ctx := context.WithValue(req.Context(), caddyhttp.VarsCtxKey, map[string]any{
+		"client_ip": "10.1.2.3",
+	})
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	if err := issuer.ServeHTTP(rr, req, nil); err != nil {
+		t.Fatalf("ServeHTTP error: %v", err)
+	}
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("Expected 500 Internal Server Error, got %d", rr.Code)
+	}
+}
+
+func TestGetClientIPFallbacks(t *testing.T) {
+	ctx := context.Background()
+	if got := getClientIP(ctx, "192.0.2.10:12345"); got != "192.0.2.10" {
+		t.Fatalf("Expected host from RemoteAddr, got %q", got)
+	}
+	if got := getClientIP(ctx, "not-a-host-port"); got != "not-a-host-port" {
+		t.Fatalf("Expected raw RemoteAddr fallback, got %q", got)
+	}
+}
+
 func TestJWTIssuer_ServeHTTP_BadPassword(t *testing.T) {
 	signKey := base64.StdEncoding.EncodeToString([]byte("12345678901234567890123456789012"))
 	pw, _ := bcrypt.GenerateFromPassword([]byte("testpass"), 14)

--- a/jwt_issuer_test.go
+++ b/jwt_issuer_test.go
@@ -34,6 +34,26 @@ func createTestUserDBFile(t *testing.T, users any) string {
 	return tmpfile.Name()
 }
 
+func TestMaskTokenForLog(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{name: "short token redacted", token: "short-token", want: "[redacted]"},
+		{name: "boundary length redacted", token: "123456789012345678901234", want: "[redacted]"},
+		{name: "long token keeps fixed tail", token: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", want: "[redacted]…CDEFGHIJKLMNOPQRSTUVWXYZ"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maskTokenForLog(tt.token); got != tt.want {
+				t.Fatalf("maskTokenForLog() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestJWTIssuer_Provision_Validate(t *testing.T) {
 	// Create a dummy sign key (32 bytes, base64)
 	signKey := base64.StdEncoding.EncodeToString([]byte("12345678901234567890123456789012"))

--- a/jwt_issuer_test.go
+++ b/jwt_issuer_test.go
@@ -121,6 +121,12 @@ func TestJWTIssuer_ServeHTTP_Success(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("Expected 200 OK, got %d", rr.Code)
 	}
+	if got := rr.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Expected Cache-Control no-store, got %q", got)
+	}
+	if got := rr.Header().Get("Pragma"); got != "no-cache" {
+		t.Fatalf("Expected Pragma no-cache, got %q", got)
+	}
 
 	var resp apiResponse
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {

--- a/matchers/token_is_blocked.go
+++ b/matchers/token_is_blocked.go
@@ -121,7 +121,13 @@ func (m *TokenIsBlocked) Cleanup() error {
 }
 
 func (m *TokenIsBlocked) Match(r *http.Request) bool {
-	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	repl, ok := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	if !ok || repl == nil {
+		if m.logger != nil {
+			m.logger.Warn("No Caddy replacer found in request context", zap.String("placeholder", m.Placeholder))
+		}
+		return false
+	}
 	token := repl.ReplaceAll(m.Placeholder, "")
 
 	if token == "" {

--- a/matchers/token_is_blocked.go
+++ b/matchers/token_is_blocked.go
@@ -4,12 +4,13 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
-
-	"net/http"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -22,7 +23,9 @@ import (
 // It uses a file watcher to reload the blocklist when the file changes.
 type TokenIsBlocked struct {
 	// BlocklistFile is the path to the blocklist file.
-	// Each line in the file should contain a token to be blocked.
+	// Each line in the file should contain a token to be blocked, optionally followed by
+	// a Unix expiration timestamp: "<token>" or "<token> <exp>". Expired entries
+	// are skipped while loading so old revocations do not consume memory indefinitely.
 	// If the file does not exist, it will be created.
 	// The file is reloaded when it changes.
 	BlocklistFile string `json:"blocklist_file,omitempty"`
@@ -156,25 +159,59 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 
 	scanner := bufio.NewScanner(file)
 	newMap := make(map[string]struct{})
+	now := time.Now().Unix()
+	skippedExpired := 0
+	malformedExp := 0
 
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line != "" {
-			newMap[line] = struct{}{}
+		// Supported line formats are "<token>" and "<token> <exp>".
+		// The first field is always the token value used for blocklist matching.
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 {
+			continue
 		}
+
+		token := fields[0]
+		if len(fields) > 1 {
+			exp, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				// Fail closed: a bad optional expiration must not accidentally unblock the token.
+				malformedExp++
+				if m.logger != nil {
+					m.logger.Warn("Ignoring malformed blocklist expiration and keeping token blocked",
+						zap.String("file", m.BlocklistFile),
+						zap.String("token", token),
+						zap.String("expiration", fields[1]),
+						zap.Error(err),
+					)
+				}
+			} else if exp <= now {
+				// JWT exp is exclusive: a token is expired at or after this Unix timestamp.
+				skippedExpired++
+				continue
+			}
+		}
+
+		// Add the token to the in-memory blocklist unless a valid exp field proved it expired.
+		newMap[token] = struct{}{}
 	}
 
 	if err := scanner.Err(); err != nil {
 		return err
 	}
 
-	// Atomically store the new map
+	// Atomically store the new map. The blocklist file remains read-only from this matcher;
+	// external housekeeping can compact expired lines on disk when appropriate.
 	m.blocked.Store(newMap)
 
-	m.logger.Info("Blocklist reloaded",
-		zap.String("file", m.BlocklistFile),
-		zap.Int("entries", len(newMap)),
-	)
+	if m.logger != nil {
+		m.logger.Info("Blocklist reloaded",
+			zap.String("file", m.BlocklistFile),
+			zap.Int("entries", len(newMap)),
+			zap.Int("skipped_expired_entries", skippedExpired),
+			zap.Int("malformed_expiration_entries", malformedExp),
+		)
+	}
 	return nil
 }
 

--- a/matchers/token_is_blocked.go
+++ b/matchers/token_is_blocked.go
@@ -164,6 +164,10 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
 	// Atomically store the new map
 	m.blocked.Store(newMap)
 

--- a/matchers/token_is_blocked.go
+++ b/matchers/token_is_blocked.go
@@ -144,6 +144,8 @@ func (m *TokenIsBlocked) Match(r *http.Request) bool {
 	_, blocked := blockedMap[token]
 
 	if blocked {
+		// The default placeholder resolves to the JWT ID (JTI), not the encoded JWT.
+		// If a custom placeholder is configured, this log field contains that configured blocklist value.
 		m.logger.Info("Token is in the blocklist", zap.String("token", token))
 		return true
 	}

--- a/matchers/token_is_blocked.go
+++ b/matchers/token_is_blocked.go
@@ -24,8 +24,9 @@ import (
 type TokenIsBlocked struct {
 	// BlocklistFile is the path to the blocklist file.
 	// Each line in the file should contain a token to be blocked, optionally followed by
-	// a Unix expiration timestamp: "<token>" or "<token> <exp>". Expired entries
-	// are skipped while loading so old revocations do not consume memory indefinitely.
+	// an expiration timestamp: "<token>" or "<token> <exp>". The expiration may be
+	// Unix seconds or RFC3339/RFC3339Nano. Expired entries are skipped while loading
+	// so old revocations do not consume memory indefinitely.
 	// If the file does not exist, it will be created.
 	// The file is reloaded when it changes.
 	BlocklistFile string `json:"blocklist_file,omitempty"`
@@ -159,7 +160,7 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 
 	scanner := bufio.NewScanner(file)
 	newMap := make(map[string]struct{})
-	now := time.Now().Unix()
+	now := time.Now()
 	skippedExpired := 0
 	malformedExp := 0
 
@@ -173,7 +174,7 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 
 		token := fields[0]
 		if len(fields) > 1 {
-			exp, err := strconv.ParseInt(fields[1], 10, 64)
+			exp, err := parseBlocklistExpiration(fields[1])
 			if err != nil {
 				// Fail closed: a bad optional expiration must not accidentally unblock the token.
 				malformedExp++
@@ -185,8 +186,8 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 						zap.Error(err),
 					)
 				}
-			} else if exp <= now {
-				// JWT exp is exclusive: a token is expired at or after this Unix timestamp.
+			} else if !exp.After(now) {
+				// JWT exp is exclusive: a token is expired at or after this timestamp.
 				skippedExpired++
 				continue
 			}
@@ -213,6 +214,18 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 		)
 	}
 	return nil
+}
+
+func parseBlocklistExpiration(value string) (time.Time, error) {
+	if unixExp, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return time.Unix(unixExp, 0), nil
+	}
+
+	if exp, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return exp, nil
+	}
+
+	return time.Time{}, fmt.Errorf("expiration must be Unix seconds or RFC3339 timestamp")
 }
 
 func (m *TokenIsBlocked) watchDirectoryLoop() {

--- a/matchers/token_is_blocked_test.go
+++ b/matchers/token_is_blocked_test.go
@@ -70,6 +70,18 @@ func TestTokenIsBlocked_Match(t *testing.T) {
 	}
 }
 
+func TestTokenIsBlocked_MissingReplacerContext(t *testing.T) {
+	m := &TokenIsBlocked{
+		Placeholder: "{token}",
+	}
+	m.logger = zaptest.NewLogger(t)
+	req, _ := http.NewRequest("GET", "/", nil)
+
+	if m.Match(req) {
+		t.Fatal("Expected missing replacer context to not match")
+	}
+}
+
 func TestTokenIsBlocked_UnmarshalCaddyfile(t *testing.T) {
 	input := `
 	token_is_blocked {

--- a/matchers/token_is_blocked_test.go
+++ b/matchers/token_is_blocked_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -67,6 +68,46 @@ func TestTokenIsBlocked_Match(t *testing.T) {
 	req := makeReqWithToken("notblocked")
 	if m.Match(req) {
 		t.Errorf("Expected token %q to NOT be blocked", "notblocked")
+	}
+}
+
+func TestTokenIsBlocked_LoadBlocklistWithOptionalExpiration(t *testing.T) {
+	futureExp := strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10)
+	expiredExp := strconv.FormatInt(time.Now().Add(-time.Hour).Unix(), 10)
+	blocklistFile := createTempBlocklistFile(t, []string{
+		"plain-token",
+		"future-token " + futureExp,
+		"expired-token " + expiredExp,
+		"malformed-token not-a-unix-time",
+	})
+	defer os.Remove(blocklistFile)
+
+	m := &TokenIsBlocked{
+		BlocklistFile: blocklistFile,
+		Placeholder:   "{token}",
+	}
+	m.logger = zaptest.NewLogger(t)
+	if err := m.loadBlocklist(); err != nil {
+		t.Fatalf("loadBlocklist failed: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		token   string
+		blocked bool
+	}{
+		{name: "plain token stays blocked", token: "plain-token", blocked: true},
+		{name: "future expiration stays blocked", token: "future-token", blocked: true},
+		{name: "expired token is skipped", token: "expired-token", blocked: false},
+		{name: "malformed expiration fails closed", token: "malformed-token", blocked: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := m.Match(makeReqWithToken(tt.token)); got != tt.blocked {
+				t.Fatalf("Match() = %v, want %v", got, tt.blocked)
+			}
+		})
 	}
 }
 

--- a/matchers/token_is_blocked_test.go
+++ b/matchers/token_is_blocked_test.go
@@ -74,10 +74,14 @@ func TestTokenIsBlocked_Match(t *testing.T) {
 func TestTokenIsBlocked_LoadBlocklistWithOptionalExpiration(t *testing.T) {
 	futureExp := strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10)
 	expiredExp := strconv.FormatInt(time.Now().Add(-time.Hour).Unix(), 10)
+	futureRFC3339Exp := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	expiredRFC3339Exp := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
 	blocklistFile := createTempBlocklistFile(t, []string{
 		"plain-token",
 		"future-token " + futureExp,
 		"expired-token " + expiredExp,
+		"future-rfc3339-token " + futureRFC3339Exp,
+		"expired-rfc3339-token " + expiredRFC3339Exp,
 		"malformed-token not-a-unix-time",
 	})
 	defer os.Remove(blocklistFile)
@@ -99,6 +103,8 @@ func TestTokenIsBlocked_LoadBlocklistWithOptionalExpiration(t *testing.T) {
 		{name: "plain token stays blocked", token: "plain-token", blocked: true},
 		{name: "future expiration stays blocked", token: "future-token", blocked: true},
 		{name: "expired token is skipped", token: "expired-token", blocked: false},
+		{name: "future RFC3339 expiration stays blocked", token: "future-rfc3339-token", blocked: true},
+		{name: "expired RFC3339 token is skipped", token: "expired-rfc3339-token", blocked: false},
 		{name: "malformed expiration fails closed", token: "malformed-token", blocked: true},
 	}
 


### PR DESCRIPTION
# Pull Request: Security hardening

## Summary

This PR applies a set of focused security hardening changes identified during the review of the JWT issuer and token blocklist flow using Codex CLI.

- Prevent JWT responses from being cacheable by switching JSON responses to `Cache-Control: no-store` and `Pragma: no-cache`.
- Avoid request panics when expected Caddy context values are missing; the issuer now returns a controlled error and the matcher fails closed by not matching.
- Improve token blocklist loading so entries may optionally include an `exp` timestamp in Unix seconds or RFC3339/RFC3339Nano format; expired entries are skipped in memory while the matcher remains read-only and backward compatible with one-JTI-per-line files.
- Stop logging full JWT bearer tokens; debug logs now include only a redacted token marker plus the last 24 characters for correlation.
- Update README and example configuration to document the optional `<jti> <exp>` blocklist format, including the RFC3339 value written by `{http.auth.user.exp}` via `placeholder_dump`.

## Details

### Token response cache headers

- `jsonResponse` now sets `Cache-Control: no-store`.
- `Pragma` was changed from `private` to `no-cache` for legacy cache behavior.
- A test assertion verifies successful token responses carry the expected headers.

### Missing context handling

- `getClientIP` safely checks for Caddy request vars before falling back to `RemoteAddr`.
- JWT creation returns an error if the Caddy replacer is missing instead of panicking.
- `token_is_blocked` returns `false` if no replacer is available in the request context.
- Regression tests cover the issuer and matcher missing-context paths.

### Blocklist housekeeping

- The blocklist reader accepts both formats:

```text
<jti>
<jti> <exp>
```

- The first whitespace-separated field is always treated as the token/JTI.
- The optional second field is parsed as either Unix seconds or an RFC3339/RFC3339Nano timestamp.
- Entries with expiration timestamps at or before the current time are skipped and not loaded into memory.
- Malformed expiration values fail closed: the token remains blocked and a warning is logged.
- The matcher does not rewrite or compact the blocklist file; external housekeeping remains responsible for on-disk cleanup.

### JWT log masking

- `logJWTDetails` no longer logs the full encoded JWT.
- Full JWTs are replaced with `maskTokenForLog(tokenString)`.
- The masking format is `[redacted]…<last 24 chars>` for longer tokens and `[redacted]` for short tokens.

## Notes

- Existing one-JTI-per-line blocklist files remain supported.
