### PR TITLE
Resolve golangci-lint findings

### DIFF
--- a/api.go
+++ b/api.go
@@ -25,16 +25,16 @@ type apiResponse struct {
 }
 
 // jsonResponse sends a generic JSON response with a message and optional token
-func jsonResponse(w http.ResponseWriter, statusCode int, response apiResponse) {
+func jsonResponse(w http.ResponseWriter, statusCode int, response apiResponse) error {
 	w.Header().Set("Content-Type", "application/json")
 	// Token-bearing responses must not be stored by browsers or intermediaries.
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(statusCode)
-	json.NewEncoder(w).Encode(response)
+	return json.NewEncoder(w).Encode(response)
 }
 
 // jsonError simplifies sending error messages in JSON format
-func jsonError(w http.ResponseWriter, statusCode int, message string) {
-	jsonResponse(w, statusCode, apiResponse{Message: message})
+func jsonError(w http.ResponseWriter, statusCode int, message string) error {
+	return jsonResponse(w, statusCode, apiResponse{Message: message})
 }

--- a/jwt_issuer.go
+++ b/jwt_issuer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -195,15 +196,13 @@ func (m *JWTIssuer) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 	var providedCredentials credentials
 	if err := json.NewDecoder(r.Body).Decode(&providedCredentials); err != nil {
 		logger.Error("Error decoding credentials", zap.Error(err))
-		jsonError(w, http.StatusBadRequest, "Invalid request payload.")
-		return nil
+		return jsonError(w, http.StatusBadRequest, "Invalid request payload.")
 	}
 
 	// Check if username was provided
 	if providedCredentials.Username == "" {
 		logger.Error("No username provided")
-		jsonError(w, http.StatusBadRequest, "Missing username value")
-		return nil
+		return jsonError(w, http.StatusBadRequest, "Missing username value")
 	}
 
 	// Retrieve the user entry from the in-memory user database
@@ -215,25 +214,25 @@ func (m *JWTIssuer) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 		// The cost of 14 is chosen to match the bcrypt cost used for real passwords
 		// This prevents attackers from knowing if a user does not exist based on the time taken
 		fakeHash := "$2a$14$BS8pSBcO76nFFFvzQuZuPe5nahDaA2QkXaUnUp4ND6k1ax4Ohi39m"
-		bcrypt.CompareHashAndPassword([]byte(fakeHash), []byte(providedCredentials.Password))
+		if err := bcrypt.CompareHashAndPassword([]byte(fakeHash), []byte(providedCredentials.Password)); err != nil &&
+			!errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+			logger.Error("Dummy password comparison failed", zap.Error(err))
+		}
 		logger.Warn("Authentication failed due to incorrect username",
 			zap.String("username", providedCredentials.Username),
 		)
-		jsonError(w, http.StatusUnauthorized, "Unauthorized: Incorrect username or password")
-		return nil
+		return jsonError(w, http.StatusUnauthorized, "Unauthorized: Incorrect username or password")
 	}
 
 	// Validate the user entry for missing fields
 	if err := m.validateUserEntry(userEntry, providedCredentials.Username, clientIP); err != nil {
-		jsonError(w, http.StatusInternalServerError, "Internal server error")
-		return nil
+		return jsonError(w, http.StatusInternalServerError, "Internal server error")
 	}
 
 	// Verify the provided password against the stored hash
 	if bcrypt.CompareHashAndPassword([]byte(userEntry.Password), []byte(providedCredentials.Password)) != nil {
 		logger.Warn("Authentication failed due to wrong password", zap.String("username", providedCredentials.Username))
-		jsonError(w, http.StatusUnauthorized, "Unauthorized: Incorrect username or password")
-		return nil
+		return jsonError(w, http.StatusUnauthorized, "Unauthorized: Incorrect username or password")
 	}
 
 	// Check if token issuance is disabled for this user
@@ -242,8 +241,7 @@ func (m *JWTIssuer) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 			zap.String("username", providedCredentials.Username),
 			zap.Time("disabled_after", *userEntry.TokenIssuanceDisabledAfter),
 		)
-		jsonError(w, http.StatusUnauthorized, "Unauthorized: Incorrect username or password")
-		return nil
+		return jsonError(w, http.StatusUnauthorized, "Unauthorized: Incorrect username or password")
 	}
 
 	// Create the JWT
@@ -251,8 +249,7 @@ func (m *JWTIssuer) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 	logger = logger.With(zap.String("username", userEntry.Username))
 	if err != nil {
 		logger.Error("Failed to create JWT", zap.Error(err))
-		jsonError(w, http.StatusInternalServerError, "Internal server error")
-		return nil
+		return jsonError(w, http.StatusInternalServerError, "Internal server error")
 	}
 
 	// Log successful JWT issuance
@@ -285,8 +282,7 @@ func (m *JWTIssuer) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 		response.Token = tokenString
 	}
 
-	jsonResponse(w, http.StatusOK, response)
-	return nil
+	return jsonResponse(w, http.StatusOK, response)
 }
 
 // getClientIP retrieves the client IP address directly from the Caddy context.

--- a/jwt_issuer_test.go
+++ b/jwt_issuer_test.go
@@ -22,13 +22,15 @@ import (
 
 func createTestUserDBFile(t *testing.T, users any) string {
 	t.Helper()
-	tmpfile, err := os.CreateTemp("", "userdb-*.json")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "userdb-*.json")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tmpfile.Close()
 	enc := json.NewEncoder(tmpfile)
 	if err := enc.Encode(users); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
 		t.Fatal(err)
 	}
 	return tmpfile.Name()
@@ -66,7 +68,6 @@ func TestJWTIssuer_Provision_Validate(t *testing.T) {
 		},
 	}
 	userDB := createTestUserDBFile(t, users)
-	defer os.Remove(userDB)
 
 	issuer := &JWTIssuer{
 		SignKey:              signKey,
@@ -99,7 +100,6 @@ func TestJWTIssuer_ServeHTTP_Success(t *testing.T) {
 		},
 	}
 	userDB := createTestUserDBFile(t, users)
-	defer os.Remove(userDB)
 
 	issuer := &JWTIssuer{
 		SignKey:              signKey,
@@ -179,7 +179,6 @@ func TestJWTIssuer_ServeHTTP_OmitToken(t *testing.T) {
 		},
 	}
 	userDB := createTestUserDBFile(t, users)
-	defer os.Remove(userDB)
 
 	issuer := &JWTIssuer{
 		SignKey:              signKey,
@@ -258,7 +257,6 @@ func TestJWTIssuer_ServeHTTP_MissingReplacerContext(t *testing.T) {
 		},
 	}
 	userDB := createTestUserDBFile(t, users)
-	defer os.Remove(userDB)
 
 	issuer := &JWTIssuer{
 		SignKey:              signKey,
@@ -311,7 +309,6 @@ func TestJWTIssuer_ServeHTTP_BadPassword(t *testing.T) {
 		},
 	}
 	userDB := createTestUserDBFile(t, users)
-	defer os.Remove(userDB)
 
 	issuer := &JWTIssuer{
 		SignKey:              signKey,
@@ -374,7 +371,6 @@ func TestJWTIssuer_ServeHTTP_TokenIssuanceDisabled(t *testing.T) {
 		},
 	}
 	userDB := createTestUserDBFile(t, users)
-	defer os.Remove(userDB)
 
 	issuer := &JWTIssuer{
 		SignKey:              signKey,
@@ -452,7 +448,6 @@ func TestCaddyfileJWTIssuer(t *testing.T) {
 		},
 	}
 	userDB := createTestUserDBFile(t, users)
-	defer os.Remove(userDB)
 
 	caddyfile := `
 	{
@@ -483,8 +478,13 @@ func TestCaddyfileJWTIssuer(t *testing.T) {
 		t.Fatalf("Failed to create GET request: %v", err)
 	}
 	resp := tester.AssertResponseCode(req, 405)
-	body, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read GET response body: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("Failed to close GET response body: %v", err)
+	}
 	if !strings.Contains(string(body), "Method Not Allowed") {
 		t.Errorf("Expected method not allowed, got: %s", string(body))
 	}
@@ -496,8 +496,13 @@ func TestCaddyfileJWTIssuer(t *testing.T) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp = tester.AssertResponseCode(req, 400)
-	body, _ = io.ReadAll(resp.Body)
-	resp.Body.Close()
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read POST response body: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("Failed to close POST response body: %v", err)
+	}
 	if !strings.Contains(string(body), "Invalid request payload") {
 		t.Errorf("Expected invalid request payload, got: %s", string(body))
 	}
@@ -508,8 +513,13 @@ func TestCaddyfileJWTIssuer(t *testing.T) {
 		t.Fatalf("Failed to create GET request: %v", err)
 	}
 	resp = tester.AssertResponseCode(req, 200)
-	body, _ = io.ReadAll(resp.Body)
-	resp.Body.Close()
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read fallback response body: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("Failed to close fallback response body: %v", err)
+	}
 	if !strings.Contains(string(body), "ok") {
 		t.Errorf("Expected ok, got: %s", string(body))
 	}

--- a/matchers/token_is_blocked.go
+++ b/matchers/token_is_blocked.go
@@ -88,7 +88,9 @@ func (m *TokenIsBlocked) Provision(ctx caddy.Context) error {
 		if createErr != nil {
 			return fmt.Errorf("failed to create blocklist file: %w", createErr)
 		}
-		file.Close()
+		if closeErr := file.Close(); closeErr != nil {
+			return fmt.Errorf("failed to close newly created blocklist file: %w", closeErr)
+		}
 		m.logger.Info("Blocklist file created", zap.String("file", m.BlocklistFile))
 	}
 
@@ -153,12 +155,19 @@ func (m *TokenIsBlocked) Match(r *http.Request) bool {
 	return false
 }
 
+// MatchWithError implements caddyhttp.RequestMatcherWithError. Match is kept
+// for compatibility with Caddy versions that use the legacy matcher interface.
+func (m *TokenIsBlocked) MatchWithError(r *http.Request) (bool, error) {
+	return m.Match(r), nil
+}
+
 func (m *TokenIsBlocked) loadBlocklist() error {
 	file, err := os.Open(m.BlocklistFile)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	// The file is closed explicitly below so close errors are handled before new state is published.
+	// Any future early-return path added while scanning must close the file as well.
 
 	scanner := bufio.NewScanner(file)
 	newMap := make(map[string]struct{})
@@ -176,8 +185,8 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 
 		token := fields[0]
 		if len(fields) > 1 {
-			exp, err := parseBlocklistExpiration(fields[1])
-			if err != nil {
+			exp, parseErr := parseBlocklistExpiration(fields[1])
+			if parseErr != nil {
 				// Fail closed: a bad optional expiration must not accidentally unblock the token.
 				malformedExp++
 				if m.logger != nil {
@@ -185,7 +194,7 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 						zap.String("file", m.BlocklistFile),
 						zap.String("token", token),
 						zap.String("expiration", fields[1]),
-						zap.Error(err),
+						zap.Error(parseErr),
 					)
 				}
 			} else if !exp.After(now) {
@@ -199,8 +208,11 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 		newMap[token] = struct{}{}
 	}
 
-	if err := scanner.Err(); err != nil {
-		return err
+	if scanErr := scanner.Err(); scanErr != nil {
+		return errors.Join(scanErr, file.Close())
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("closing blocklist file failed: %w", err)
 	}
 
 	// Atomically store the new map. The blocklist file remains read-only from this matcher;
@@ -215,6 +227,7 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 			zap.Int("malformed_expiration_entries", malformedExp),
 		)
 	}
+
 	return nil
 }
 
@@ -258,8 +271,8 @@ func (m *TokenIsBlocked) watchDirectoryLoop() {
 
 // Interface guards
 var (
-	_ caddy.Module             = (*TokenIsBlocked)(nil)
-	_ caddy.Provisioner        = (*TokenIsBlocked)(nil)
-	_ caddy.CleanerUpper       = (*TokenIsBlocked)(nil)
-	_ caddyhttp.RequestMatcher = (*TokenIsBlocked)(nil)
+	_ caddy.Module                      = (*TokenIsBlocked)(nil)
+	_ caddy.Provisioner                 = (*TokenIsBlocked)(nil)
+	_ caddy.CleanerUpper                = (*TokenIsBlocked)(nil)
+	_ caddyhttp.RequestMatcherWithError = (*TokenIsBlocked)(nil)
 )

--- a/matchers/token_is_blocked.go
+++ b/matchers/token_is_blocked.go
@@ -166,8 +166,14 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 	if err != nil {
 		return err
 	}
-	// The file is closed explicitly below so close errors are handled before new state is published.
-	// Any future early-return path added while scanning must close the file as well.
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && m.logger != nil {
+			m.logger.Warn("Failed to close blocklist file",
+				zap.String("file", m.BlocklistFile),
+				zap.Error(closeErr),
+			)
+		}
+	}()
 
 	scanner := bufio.NewScanner(file)
 	newMap := make(map[string]struct{})
@@ -209,10 +215,7 @@ func (m *TokenIsBlocked) loadBlocklist() error {
 	}
 
 	if scanErr := scanner.Err(); scanErr != nil {
-		return errors.Join(scanErr, file.Close())
-	}
-	if err := file.Close(); err != nil {
-		return fmt.Errorf("closing blocklist file failed: %w", err)
+		return scanErr
 	}
 
 	// Atomically store the new map. The blocklist file remains read-only from this matcher;

--- a/matchers/token_is_blocked_test.go
+++ b/matchers/token_is_blocked_test.go
@@ -15,14 +15,18 @@ import (
 
 func createTempBlocklistFile(t *testing.T, tokens []string) string {
 	t.Helper()
-	tmpfile, err := os.CreateTemp("", "blocklist-*.txt")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "blocklist-*.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, token := range tokens {
-		_, _ = tmpfile.WriteString(token + "\n")
+		if _, err := tmpfile.WriteString(token + "\n"); err != nil {
+			t.Fatal(err)
+		}
 	}
-	tmpfile.Close()
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
 	return tmpfile.Name()
 }
 
@@ -40,7 +44,6 @@ func makeReqWithToken(token string) *http.Request {
 func TestTokenIsBlocked_Match(t *testing.T) {
 	blockedTokens := []string{"blockedtoken1", "blockedtoken2"}
 	blocklistFile := createTempBlocklistFile(t, blockedTokens)
-	defer os.Remove(blocklistFile)
 
 	m := &TokenIsBlocked{
 		BlocklistFile: blocklistFile,
@@ -54,7 +57,11 @@ func TestTokenIsBlocked_Match(t *testing.T) {
 	if err := m.Provision(stubCaddyCtx); err != nil {
 		t.Fatalf("Provision failed: %v", err)
 	}
-	defer m.Cleanup()
+	t.Cleanup(func() {
+		if err := m.Cleanup(); err != nil {
+			t.Errorf("Cleanup failed: %v", err)
+		}
+	})
 
 	// Should match blocked tokens
 	for _, token := range blockedTokens {
@@ -84,7 +91,6 @@ func TestTokenIsBlocked_LoadBlocklistWithOptionalExpiration(t *testing.T) {
 		"expired-rfc3339-token " + expiredRFC3339Exp,
 		"malformed-token not-a-unix-time",
 	})
-	defer os.Remove(blocklistFile)
 
 	m := &TokenIsBlocked{
 		BlocklistFile: blocklistFile,
@@ -152,7 +158,6 @@ func TestTokenIsBlocked_UnmarshalCaddyfile(t *testing.T) {
 func TestTokenIsBlocked_FileWatcherReload(t *testing.T) {
 	blockedTokens := []string{"tokenA"}
 	blocklistFile := createTempBlocklistFile(t, blockedTokens)
-	defer os.Remove(blocklistFile)
 
 	m := &TokenIsBlocked{
 		BlocklistFile: blocklistFile,
@@ -163,7 +168,11 @@ func TestTokenIsBlocked_FileWatcherReload(t *testing.T) {
 	if err := m.Provision(stubCaddyCtx); err != nil {
 		t.Fatalf("Provision failed: %v", err)
 	}
-	defer m.Cleanup()
+	t.Cleanup(func() {
+		if err := m.Cleanup(); err != nil {
+			t.Errorf("Cleanup failed: %v", err)
+		}
+	})
 
 	// Initially blocked
 	if !m.Match(makeReqWithToken("tokenA")) {
@@ -179,8 +188,12 @@ func TestTokenIsBlocked_FileWatcherReload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to open blocklist file: %v", err)
 	}
-	_, _ = f.WriteString("tokenB\n")
-	f.Close()
+	if _, err := f.WriteString("tokenB\n"); err != nil {
+		t.Fatalf("Failed to append to blocklist file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Failed to close blocklist file: %v", err)
+	}
 
 	// Wait for watcher to reload (should be quick, but allow up to 500ms)
 	found := false

--- a/user_test.go
+++ b/user_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestValidateUserEntry(t *testing.T) {
-	logger, _ := zap.NewProduction()
-	defer logger.Sync()
+	logger := zaptest.NewLogger(t)
 
 	jwtIssuer := &JWTIssuer{
 		logger:     logger,
@@ -70,8 +69,7 @@ func TestValidateUserEntry(t *testing.T) {
 }
 
 func TestLoadUsers(t *testing.T) {
-	logger, _ := zap.NewProduction()
-	defer logger.Sync()
+	logger := zaptest.NewLogger(t)
 
 	jwtIssuer := &JWTIssuer{
 		logger:     logger,
@@ -95,16 +93,16 @@ func TestLoadUsers(t *testing.T) {
 		},
 	}
 
-	file, err := os.CreateTemp("", "users.json")
+	file, err := os.CreateTemp(t.TempDir(), "users.json")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
-	defer os.Remove(file.Name())
-
 	if err := json.NewEncoder(file).Encode(userData); err != nil {
 		t.Fatalf("Failed to write to temp file: %v", err)
 	}
-	file.Close()
+	if err := file.Close(); err != nil {
+		t.Fatalf("Failed to close temp file: %v", err)
+	}
 
 	if err := jwtIssuer.loadUsers(file.Name()); err != nil {
 		t.Errorf("loadUsers() error = %v", err)


### PR DESCRIPTION
This PR resolves all findings reported by `golangci-lint`:

- Propagate JSON response encoding errors through the Caddy handler.
- Explicitly handle the intentional dummy bcrypt comparison while preserving timing-attack protection.
- Handle file, response body, and matcher cleanup errors.
- Use test-managed temporary directories and test loggers.
- Implement Caddy's current `RequestMatcherWithError` interface while retaining the legacy `Match` method for compatibility.
- Log read-only blocklist file close failures without discarding successfully parsed updates.

## Verification

- `go test -v ./...`
- `golangci-lint run`
